### PR TITLE
ref: remove certifi, also upgrade dependencies

### DIFF
--- a/freight_cli.py
+++ b/freight_cli.py
@@ -35,10 +35,6 @@ class Api(object):
         if self._session is not None:
             return self._session
         session = connection_from_url(self.base_url)
-        if session.scheme == "https":
-            import certifi
-
-            session.ca_certs = certifi.where()
         session.headers.update(
             {
                 "Accept": "application/json",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ["click>=7,<7.1", "urllib3[secure]>=1.25,<1.26"]
+install_requires = ["click", "urllib3==1.26.10"]
 
 setup(
     name="freight-cli",


### PR DESCRIPTION
cryptography will be pulled in and tends to install from source on debian 10 (salted machine), which is a huge pain (need to install libpython3-dev,  libffi, and the full rust toolchain)

certifi isn't needed, https works fine here, also in the future since newfreight is behind google IAP, freight-cli will only be used http localhost.