### PR TITLE
ref: fix modules when installing freight-cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ["click>=7,<7.1", "urllib3[secure]>=1.25,<1.26"]
+install_requires = ["click>=7", "urllib3[secure]>=1.25,<1.26"]
 
 setup(
     name="freight-cli",
@@ -10,12 +10,11 @@ setup(
     url="https://github.com/getsentry/freight-cli",
     description="A command line interface to Freight",
     long_description=open("README.md").read(),
-    packages=find_packages(),
-    zip_safe=False,
     install_requires=install_requires,
     entry_points={"console_scripts": ["freight=freight_cli:cli"]},
+    py_modules=["freight_cli"],
     license="Apache 2.0",
-    include_package_data=True,
+    license_file='LICENSE',
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
the main change is the `py_modules` -- otherwise this errors with:

```console
$ freight --help
Traceback (most recent call last):
  File "/home/asottile/workspace/freight/venv/bin/freight", line 5, in <module>
    from freight_cli import cli
ModuleNotFoundError: No module named 'freight_cli'
```